### PR TITLE
Removes install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember test",
-    "install": "bower install"
+    "test": "ember test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The inclusion of the install script causes issues if installation via npm needs to be run as root e.g. when running commands within a Docker image build.